### PR TITLE
Expose user id in res.locals for easy use later in the app.

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ function validateSession(req, res, next){
             } else {
                 debug('Session is valid. Allowing request to continue.');
                 res.clearCookie('w3id_redirect');
+                res.locals.w3id_userid = req.cookies['w3id_userid'];
                 next();
             }
 


### PR DESCRIPTION
Useful if the application developer wants to set up a whitelist of users, perhaps on a team-by-team or person-by-person basis.